### PR TITLE
:wrench: expose default port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER devops@leonisand.co
 
 RUN apk add --no-cache --virtual .dependency curl && \
-    curl -L http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest | /bin/tar xz && \
+    curl -L http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz | /bin/tar xz && \
     apk del .dependency
 
 ENTRYPOINT ["java", "-Djava.library.path=./DynamoDBLocal_lib", "-jar", "DynamoDBLocal.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN apk add --no-cache --virtual .dependency curl && \
 
 ENTRYPOINT ["java", "-Djava.library.path=./DynamoDBLocal_lib", "-jar", "DynamoDBLocal.jar"]
 
+EXPOSE 8000
+
 CMD ["-help"]


### PR DESCRIPTION
Expose default port.

## Detail

According to [aws document](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html), the default port is `8000`.
So this docker image should define 8000 port as `exposed`. 👍 